### PR TITLE
Use Kelvin attributes for color temperature range

### DIFF
--- a/custom_components/govee/light.py
+++ b/custom_components/govee/light.py
@@ -123,6 +123,9 @@ class GoveeDataUpdateCoordinator(DataUpdateCoordinator):
 class GoveeLightEntity(LightEntity):
     """Representation of a Govee light."""
 
+    _attr_min_color_temp_kelvin = COLOR_TEMP_KELVIN_MIN
+    _attr_max_color_temp_kelvin = COLOR_TEMP_KELVIN_MAX
+
     def __init__(self, hub: GoveeClient, title: str, coordinator: GoveeDataUpdateCoordinator, device: GoveeDevice):
         self._hub = hub
         self._title = title


### PR DESCRIPTION
## Summary
- expose `_attr_min_color_temp_kelvin` and `_attr_max_color_temp_kelvin` in `GoveeLightEntity` so Home Assistant uses Kelvin instead of mireds

## Testing
- `python -m py_compile custom_components/govee/light.py`


------
https://chatgpt.com/codex/tasks/task_e_68bee1a064c88331967fc853b1e0355f