### PR TITLE
Fix token extraction during Govee login

### DIFF
--- a/custom_components/govee/iot_client.py
+++ b/custom_components/govee/iot_client.py
@@ -64,7 +64,6 @@ def _extract_token(payload: Dict[str, Any]) -> str | None:
         if isinstance(token, str) and token:
             _LOGGER.debug("Login token found under key '%s'", key)
             return token
-        codex/investigate-govee-login-failure-handling-ua7guo
 
     # Common containers for tokens observed in various API responses
     for container_key in ("data", "client"):
@@ -77,7 +76,6 @@ def _extract_token(payload: Dict[str, Any]) -> str | None:
     nested = payload.get("data")
     if isinstance(nested, dict):
         return _extract_token(nested)
-        iotmqtt
     return None
 
 


### PR DESCRIPTION
## Summary
- fix NameError in `_extract_token` by removing stray text

## Testing
- `python -m py_compile custom_components/govee/iot_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c50b5577548331b93289cef69e15d2